### PR TITLE
Integrate zone cleaning support for Vorwerk VR 300

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 from pybotvac.exceptions import NeatoException, NeatoRobotException
 from pybotvac.robot import Robot
 from pybotvac.vorwerk import Vorwerk
+from pybotvac.session import PasswordlessSession
 import voluptuous as vol
 
 from homeassistant.components.vacuum import (
@@ -24,6 +25,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.const import CONF_TOKEN
 
 from .const import (
     ACTION,
@@ -97,6 +99,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
             {
                 VORWERK_ROBOT_API: r,
                 VORWERK_ROBOT_COORDINATOR: _create_coordinator(hass, r),
+                CONF_TOKEN: entry.data[CONF_TOKEN]
             }
             for r in robot_states
         ]

--- a/const.py
+++ b/const.py
@@ -23,6 +23,7 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 ATTR_NAVIGATION = "navigation"
 ATTR_CATEGORY = "category"
 ATTR_ZONE = "zone"
+ATTR_MAP = "map"
 
 ROBOT_STATE_INVALID = 0
 ROBOT_STATE_IDLE = 1

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/vorwerk",
   "requirements": [
-    "pybotvac==0.0.20"
+    "pybotvac==0.0.23"
   ],
   "codeowners": [
     "@trunneml"

--- a/manifest.json
+++ b/manifest.json
@@ -2,16 +2,17 @@
   "domain": "vorwerk",
   "name": "Vorwerk Kobold",
   "config_flow": true,
-  "documentation": "https://www.home-assistant.io/integrations/vorwerk",
+  "documentation": "https://github.com/trunneml/homeassistant-vorwerk",
   "requirements": [
     "pybotvac==0.0.23"
   ],
   "codeowners": [
-    "@trunneml"
+    "@trunneml",
+    "@fuempel"
   ],
   "dependencies": [
     "http"
   ],
   "iot_class": "cloud_polling",
-  "version": "0.9.6"
+  "version": "0.10.0"
 }

--- a/services.yaml
+++ b/services.yaml
@@ -16,3 +16,6 @@ custom_cleaning:
     zone:
       description: Only supported on the VR300. Name of the zone to clean. Defaults to no zone i.e. complete house cleanup.
       example: "Kitchen"
+    map:
+      description: Only supported on the VR300. Name of the map for the zone to clean. Defaults to no zone i.e. complete house cleanup.
+      example: "Ground Floor"

--- a/translations/de.json
+++ b/translations/de.json
@@ -6,14 +6,14 @@
           "data": {
             "email": "E-Mailaddresse"
           },
-          "description": "Um einen Authentifizierungscode per E-Mail zu erhalten, gib die E-Mailadresse deines Vorwerk-Accounts ein.\n\nSiehe [Vorwerk-Dokumentation]({docs_url})."
+          "description": "Um einen Authentifizierungscode per E-Mail zu erhalten, gib die E-Mailadresse deines Vorwerk-Accounts ein."
         },
         "code": {
           "title": "Vorwerk Account Info",
           "data": {
             "code": "Code"
           },
-          "description": "Gib den per E-Mail erhaltenen Code ein.\n\nSee [Vorwerk documentation]({docs_url})."
+          "description": "Gib den per E-Mail erhaltenen Code ein."
         }
       },
       "error": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -6,14 +6,14 @@
           "data": {
             "email": "Email"
           },
-          "description": "To recieve an authentication code, enter the email address of your vorwerk account.\n\nSee [Vorwerk documentation]({docs_url})."
+          "description": "To recieve an authentication code, enter the email address of your vorwerk account."
         },
         "code": {
           "title": "Vorwerk Account Info",
           "data": {
             "code": "Code"
           },
-          "description": "Enter the code you received by email.\n\nSee [Vorwerk documentation]({docs_url})."
+          "description": "Enter the code you received by email."
         }
       },
       "error": {

--- a/vacuum.py
+++ b/vacuum.py
@@ -104,7 +104,6 @@ class VorwerkConnectedVacuum(CoordinatorEntity, StateVacuumEntity):
 
         self._name = f"{self.robot.name}"
         self._robot_serial = self.robot.serial
-        self._robot_boundaries: list[str] = []
         self._token = token
 
     @property
@@ -284,24 +283,3 @@ class VorwerkConnectedVacuum(CoordinatorEntity, StateVacuumEntity):
             _LOGGER.error(
                 "Vorwerk vacuum connection error for '%s': %s", self.entity_id, ex
             )
-
-
-        # TODO: OLD CODE
-#        boundary_id = None
-#        if zone is not None:
-#            for boundary in self._robot_boundaries:
-#                if zone in boundary["name"]:
-#                    boundary_id = boundary["id"]
-#            if boundary_id is None:
-#                _LOGGER.error(
-#                    "Zone '%s' was not found for the robot '%s'", zone, self.entity_id
-#                )
-#                return
-#            _LOGGER.info("Start cleaning zone '%s' with robot %s", zone, self.entity_id)
-
-#        try:
-#            self.robot.start_cleaning(mode, navigation, category, boundary_id)
-#        except NeatoRobotException as ex:
-#            _LOGGER.error(
-#                "Vorwerk vacuum connection error for '%s': %s", self.entity_id, ex
-#            )


### PR DESCRIPTION
I implemented support for zone cleaning on Vorwerk VR 300 robots.

Following approach was taken:

- During init phase in `__init__.py`, the reading of config entries is extended to make also the token from the integration configuration steps available. Via this, `vacuum.py` will have access to the token.

- As zone names are in fact relative to maps, the services configuration (in `services.yaml`) for the custom_cleaning service was extended by a map attribute (via new const `ATTR_MAP` in const.py)

- If custom_cleaning is requested, the real checks and searches for known maps and zones happens.
- The object `VorwerkConnectedVacuum` gets the forwarded token info to allow usage of the `pybotvac` `PasswordlessSession` as a first step. 
- This will be used to request an `pybotvac` `Account` object. 
- Account allows to query the list of known maps (usually 1 per floor in the building).
- Once the correct map ID is found, a list of known boundaries (API wording for zones) is queried.
- Then cleaning can be started once map + boundary ID values for the desired zone are available.

Additional changes:
- bumped `pybotvac` to 0.0.23
- `manifest.json`: version updated to 0.10.0, link for documentation changed to HACS component repository, code owners updated
- fixed translation error during component init by removing missing link to Vorwerk Dokumentation / docs_url